### PR TITLE
Use xmlrpc super_stable build

### DIFF
--- a/rtorrent/compiletorrent.sh
+++ b/rtorrent/compiletorrent.sh
@@ -13,7 +13,7 @@ make install && \
 cd .. && \
 rm -rf curl-* && \
 ldconfig && \
-svn --non-interactive --trust-server-cert checkout https://svn.code.sf.net/p/xmlrpc-c/code/stable/ xmlrpc-c && \
+svn --non-interactive --trust-server-cert checkout https://svn.code.sf.net/p/xmlrpc-c/code/super_stable/ xmlrpc-c && \
 cd xmlrpc-c && \
 ./configure --enable-libxml2-backend --disable-abyss-server --disable-cgi-server && \
 make -j -l2 && \


### PR DESCRIPTION
Using the "stable" build of xmlrpc gave me an error during compiling on raspberry pi zero. The error was the same of this issue: https://github.com/kfei/docktorrent/issues/42

Using the "super_stable" build fixed it and allowed to finish the compilation correctly.